### PR TITLE
Use defaults

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -80,3 +80,100 @@ func TestGlob(t *testing.T) {
 		}
 	}
 }
+
+func TestNoBaseViper(t *testing.T) {
+
+	expected := func(vp *viper.Viper, key string, val int) bool {
+		if vp.GetInt(key) == val {
+			return true
+		}
+		t.Errorf("unexpected value for %s: %d", key, vp.GetInt(key))
+		return false
+	}
+
+	dir := setupTestDir(t, "base")
+	if dir == "" {
+		t.Error("setup failed")
+	}
+
+	// verify that without a base it only used defined values
+	writeToFiles(t, dir, 3, 1)
+	vpCh, erCh := NewFromPathsAndGlob([]string{dir}, "*.yaml")
+	if vpCh == nil || erCh == nil {
+		t.Error("NewFromPathsAndGlob")
+	}
+
+	done := make(chan bool, 1)
+	time.AfterFunc(2*time.Second, func() {
+		done <- true
+	})
+
+loop:
+	for {
+		select {
+		case <-done:
+			break loop
+		case vp := <-vpCh:
+			if !expected(vp, "val-with-no-default", 0) {
+				return
+			}
+			for i := 0; i < 3; i++ {
+				if !expected(vp, fmt.Sprintf("val-%d", i), i+1) {
+					return
+				}
+			}
+		case err := <-erCh:
+			t.Error(err)
+		}
+	}
+}
+
+func TestWithBaseViper(t *testing.T) {
+	expected := func(vp *viper.Viper, key string, val int) bool {
+		if vp.GetInt(key) == val {
+			return true
+		}
+		t.Errorf("unexpected value for %s: %d", key, vp.GetInt(key))
+		return false
+	}
+
+	dir := setupTestDir(t, "base")
+	if dir == "" {
+		t.Error("setup failed")
+	}
+
+	// verify that without a base it only used defined values
+	writeToFiles(t, dir, 3, 1)
+	viper.GetViper().SetDefault("val-with-default", 33)
+	viper.GetViper().SetDefault("val-1", 44) // should be overriden
+
+	vpCh, erCh := NewFromPathsAndGlob([]string{dir}, "*.yaml", OptionUseBaseViper)
+	if vpCh == nil || erCh == nil {
+		t.Error("NewFromPathsAndGlob")
+	}
+
+	done := make(chan bool, 1)
+	time.AfterFunc(2*time.Second, func() {
+		done <- true
+	})
+
+loop:
+	for {
+		select {
+		case <-done:
+			break loop
+		case vp := <-vpCh:
+			if !expected(vp, "val-with-default", 33) {
+				return
+			}
+			dumpConfig(t, vp)
+			for i := 0; i < 3; i++ {
+				if !expected(vp, fmt.Sprintf("val-%d", i), i+1) {
+					return
+				}
+			}
+		case err := <-erCh:
+			t.Error(err)
+		}
+	}
+}

--- a/config_test.go
+++ b/config_test.go
@@ -147,7 +147,7 @@ func TestWithBaseViper(t *testing.T) {
 	viper.GetViper().SetDefault("val-with-default", 33)
 	viper.GetViper().SetDefault("val-1", 44) // should be overriden
 
-	vpCh, erCh := NewFromPathsAndGlob([]string{dir}, "*.yaml", OptionUseBaseViper)
+	vpCh, erCh := NewFromPathsAndGlob([]string{dir}, "*.yaml", OptionUseBaseViper(viper.GetViper()))
 	if vpCh == nil || erCh == nil {
 		t.Error("NewFromPathsAndGlob")
 	}


### PR DESCRIPTION
Hi,

I noticed that the current implementation doesn't use default values set by `viper.SetDefault`, as a new viper instance is used for `base` rather than the default/static one. I therefore added an option to control which instance (if any) is used for the `base`. 
The implementation uses the [Options Pattern](https://dave.cheney.net/2014/10/17/functional-options-for-friendly-apis) which doesn't break the existing API, so was easy to add. 

Cheers,
Shmul